### PR TITLE
feat(qr): add qrcode.react and integrate downloadable QR in SharePoll

### DIFF
--- a/components/polls/share-poll.tsx
+++ b/components/polls/share-poll.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
 import { Share2, Copy, Check, Twitter, Facebook, Linkedin } from "lucide-react"
 import { Poll } from "@/lib/types/poll"
+import { QRCode } from "@/components/qr/QRCode"
 
 interface SharePollProps {
   poll: Poll
@@ -116,17 +117,10 @@ export function SharePoll({ poll }: SharePollProps) {
           </div>
         </div>
 
-        {/* QR Code Placeholder */}
+        {/* QR Code */}
         <div className="space-y-2">
           <label className="text-sm font-medium">QR Code</label>
-          <div className="p-4 border-2 border-dashed border-muted-foreground/25 rounded-lg text-center">
-            <p className="text-sm text-muted-foreground">
-              QR Code will be generated here
-            </p>
-            <p className="text-xs text-muted-foreground mt-1">
-              Scan to share on mobile devices
-            </p>
-          </div>
+          <QRCode value={pollUrl} className="p-2" fileName={`poll-${poll.id}-qr.png`} />
         </div>
 
         {/* Share Stats */}

--- a/components/qr/QRCode.tsx
+++ b/components/qr/QRCode.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import React, { useRef } from "react"
+import QRCodeReact from "qrcode.react"
+import { Button } from "@/components/ui/button"
+
+interface QRCodeProps {
+  value: string
+  size?: number
+  className?: string
+  fileName?: string
+}
+
+export function QRCode({ value, size = 160, className, fileName = "qr-code.png" }: QRCodeProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+
+  const handleDownload = () => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const link = document.createElement("a")
+    link.href = canvas.toDataURL("image/png")
+    link.download = fileName
+    link.click()
+  }
+
+  return (
+    <div className={className}>
+      <div className="flex items-center justify-center p-3 bg-white rounded-md border">
+        <QRCodeReact value={value} size={size} renderAs="canvas" includeMargin={true} ref={canvasRef as any} />
+      </div>
+      <div className="mt-2 flex justify-center">
+        <Button variant="outline" size="sm" onClick={handleDownload}>Download QR</Button>
+      </div>
+    </div>
+  )
+}
+
+

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-radio-group": "^1.3.8",
+    "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-select": "^2.2.6",
+    "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
@@ -35,7 +37,8 @@
     "sonner": "^2.0.7",
     "swr": "^2.3.6",
     "tailwind-merge": "^3.3.1",
-    "zod": "^4.1.5"
+    "zod": "^4.1.5",
+    "qrcode.react": "^4.0.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Share Poll now displays a live QR code for the poll URL instead of a placeholder.
  * One-click “Download QR” saves the code as a PNG file named with the poll ID.
  * Improved, styled QR code container for clearer sharing.

* **Chores**
  * Added dependencies for QR code rendering and supporting UI components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->